### PR TITLE
Version 24.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 44dd239f1a779b9dcf8ebc9401a611fd7f7e3e14578dcf22c265dfaf7c1514b8
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   entry_points:
     - hatch-fancy-pypi-readme=hatch_fancy_pypi_readme.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hatch-fancy-pypi-readme" %}
-{% set version = "22.8.0" %}
+{% set version = "24.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hatch_fancy_pypi_readme-{{ version }}.tar.gz
-  sha256: da91282ca09601c18aded8e378daf8b578c70214866f0971156ee9bb9ce6c26a
+  sha256: 44dd239f1a779b9dcf8ebc9401a611fd7f7e3e14578dcf22c265dfaf7c1514b8
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,12 @@ requirements:
   host:
     - hatchling
     - pip
-    - python >=3.7
+    - python
   run:
     - hatchling
-    - python >=3.7
-    - tomli
-    - typing-extensions
+    - python
+    - tomli  # [py<311]
+    - typing-extensions  # [py<38]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,9 +50,17 @@ test:
 about:
   home: https://github.com/hynek/hatch-fancy-pypi-readme
   summary: Fancy PyPI READMEs with Hatch
+  description: |
+    hatch-fancy-pypi-readme is a Hatch metadata plugin for everyone who cares about the first impression
+    of their project’s PyPI landing page. It allows you to define your PyPI project description in terms of
+    concatenated fragments that are based on static strings, files, and most importantly: parts of files defined
+    using cut-off points or regular expressions.
+  license_family: MIT
   license: MIT
   license_file:
     - LICENSE.txt
+  dev_url: https://github.com/hynek/hatch-fancy-pypi-readme
+  doc_url: https://hatch.pypa.io/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
hatch-fancy-pypi-readme 24.1.0

**Destination channel:** defaults

### Links

- [PKG-3963](https://anaconda.atlassian.net/browse/PKG-3963)
- [Upstream repository](https://github.com/hynek/hatch-fancy-pypi-readme/tree/main)
- [Upstream changelog/diff](https://github.com/hynek/hatch-fancy-pypi-readme/blob/main/CHANGELOG.md)
- Relevant dependency PRs:
  - [PKG-3954](https://anaconda.atlassian.net/browse/PKG-3954)

### Explanation of changes:

- Update to 24.1.0
- Remove noarch
- Update build script
- Linter fixes


[PKG-3963]: https://anaconda.atlassian.net/browse/PKG-3963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-3954]: https://anaconda.atlassian.net/browse/PKG-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ